### PR TITLE
Add icon folder to build.properties

### DIFF
--- a/se.redfield.cp/build.properties
+++ b/se.redfield.cp/build.properties
@@ -1,4 +1,5 @@
 source.conformalpredictioncalibrator.jar = src/
 bin.includes = plugin.xml,\
                META-INF/,\
-               conformalpredictioncalibrator.jar
+               conformalpredictioncalibrator.jar,\
+               icons/


### PR DESCRIPTION
This fixes the missing icon in the node explorer